### PR TITLE
missing semicolon on line 87;

### DIFF
--- a/bind9-docker/README.md
+++ b/bind9-docker/README.md
@@ -84,7 +84,7 @@ Copy the example `named.conf` file in the `./config/` folder of your project dir
 
 ```conf
 acl internal {
-  192.168.0.0/24
+  192.168.0.0/24;
 };
 
 options {


### PR DESCRIPTION
I know it's an example text, and the compose file should be made per project/container, but if people do copy the example file, and simply change it to their values, they will get an error, which I again know, you warned about in your video ⚠️